### PR TITLE
Update sooka_my.py

### DIFF
--- a/epg_grabber/sites/sooka_my.py
+++ b/epg_grabber/sites/sooka_my.py
@@ -1,6 +1,7 @@
 from epg_grabber.models import Programme, ChannelMetadata, Channel
 
 from datetime import date, datetime, timedelta
+from pytz import timezone
 import requests
 
 KALSIG = "1c9a9da646d991758f659424dccec62f"
@@ -127,11 +128,13 @@ def get_programs(channel_id: str, days: int = 1, channel_xml_id: str = None):
 
     programs = []
 
+    tz = timezone("Asia/Kuala_Lumpur")
+
     for obj in output['result']['objects']:
         title = obj['metas']['TitleSortName']['value']
         description = obj['metas']['LongSynopsis']['value']
-        start_date = datetime.fromtimestamp(obj['startDate'])
-        end_date = datetime.fromtimestamp(obj['endDate'])
+        start_date = tz.localize(datetime.fromtimestamp(obj['startDate']))
+        end_date = tz.localize(datetime.fromtimestamp(obj['endDate']))
 
         program_obj = Programme(
             start=start_date,


### PR DESCRIPTION
Fixes #28. 

Well it's not a wrong timezone, but correct one, unfortunately the data in the API was patched in the client side with the `+0800` timezone. We need to `localize` so we use the same timezone offset as in the client.