### PR TITLE
Fix strftime to use timezone aware instead of hardcode offset

### DIFF
--- a/epg_grabber/constants.py
+++ b/epg_grabber/constants.py
@@ -12,5 +12,5 @@ SITES_MODULE_IMPORT_PATH = "epg_grabber.sites"
 
 # EPG constants
 EPG_GENERATOR = "epg_grabber"
-EPG_XMLTV_TIMEFORMAT = "%Y%m%d%H%M%S"
+EPG_XMLTV_TIMEFORMAT = "%Y%m%d%H%M%S %z" 
 EPG_XMLTV_OFFSET = "+0000"

--- a/epg_grabber/models.py
+++ b/epg_grabber/models.py
@@ -1,4 +1,4 @@
-from epg_grabber.constants import EPG_GENERATOR, EPG_XMLTV_TIMEFORMAT, EPG_XMLTV_OFFSET
+from epg_grabber.constants import EPG_GENERATOR, EPG_XMLTV_TIMEFORMAT
 from pydantic import BaseModel, Field, validator
 from datetime import datetime
 from string import punctuation
@@ -55,8 +55,7 @@ class Programme(BaseModel):
 
     @validator("start", "stop")
     def xmltv_datetime_string(cls, value):
-        xmltv_string = value.strftime(
-            EPG_XMLTV_TIMEFORMAT) + " " + EPG_XMLTV_OFFSET
+        xmltv_string = value.strftime(EPG_XMLTV_TIMEFORMAT)
         return xmltv_string
 
     @validator("title", "desc")


### PR DESCRIPTION
#28 is still not working because at the model level, we are hardcoding the `+0000` offset instead of using timezone aware info from `datetime`.

Updated the format `EPG_XMLTV_TIMEFORMAT`.
